### PR TITLE
Don't truncate broker log file

### DIFF
--- a/jobs/broker/templates/broker-ctl.sh.erb
+++ b/jobs/broker/templates/broker-ctl.sh.erb
@@ -55,7 +55,7 @@ case $1 in
 
     exec chpst -u vcap:vcap $run_script \
       -configFilePath /var/vcap/jobs/broker/config/broker.yml \
-      2>&1 > $log_dir/broker.log
+      >> $log_dir/broker.log 2>&1
     ;;
 
   stop)


### PR DESCRIPTION
Broker logs will be truncated each time the broker process restarts, making it difficult to debug issues that have caused the broker to restart.