### PR TITLE
Remove logger from broker control script

### DIFF
--- a/jobs/broker/templates/broker-ctl.sh.erb
+++ b/jobs/broker/templates/broker-ctl.sh.erb
@@ -16,8 +16,6 @@ run_script=/var/vcap/packages/broker/bin/on-demand-service-broker
 
 pidfile=$run_dir/broker.pid
 
-script_log_tag="$(basename "$0" .sh)"
-
 ensure_dir() {
   local dir=$1
   mkdir -p "${dir}"
@@ -26,20 +24,9 @@ ensure_dir() {
 }
 export -f ensure_dir
 
-write_log() {
-  local log_tag=$1
-  local log_file=$2
-  local log_level=$3
-  local log_facility=user
-  logger --priority $log_facility.$log_level --tag $log_tag --stderr 2>> $log_file
-}
-export -f write_log
-
 log() {
-  local log_level=$1
-  local script_log_file=$log_dir/broker_ctl.log
-  shift
-  echo "$(date): $*" | write_log $script_log_tag $script_log_file $log_level
+  log_file=$log_dir/broker_ctl.log
+  echo "$(date): $*" >> $log_file
 }
 export -f log
 
@@ -49,7 +36,7 @@ ensure_dir $run_dir
 
 case $1 in
   start)
-    log info "starting broker"
+    log "starting broker"
     echo $$ > $pidfile
     ensure_dir $run_dir
 
@@ -59,7 +46,7 @@ case $1 in
     ;;
 
   stop)
-    log info "stopping broker"
+    log "stopping broker"
 
     set +e
     kill -9 $(cat $pidfile)
@@ -78,7 +65,7 @@ case $1 in
     ;;
 
   *)
-    log warning "operation '$1' is not supported"
+    log "operation '$1' is not supported"
     echo "Usage: broker-ctl.sh start/stop" >&2
     exit 1
     ;;


### PR DESCRIPTION
Avoid duplicate logs from `broker_ctl.log` when on-demand-broker-release is co-located with syslog-migration-release.

This work was done for `broker.log` in https://github.com/pivotal-cf/on-demand-service-broker-release/commit/e322c7cb8f9cf2b088dfe66cec97bb7367c0e34d.

cc: @jamesjoshuahill 