### PR TITLE
Use bosh-template's test helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bosh-template (1.3262.24.0)
+    bosh-template (2.0.0)
       semi_semantic (~> 1.2.0)
     diff-lcs (1.2.5)
     rake (11.3.0)
@@ -32,4 +32,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,15 @@ require 'yaml'
 
 require 'bosh/template/renderer'
 require 'bosh/template/property_helper'
+require 'bosh/template/test'
+
+VALID_MANDATORY_BROKER_PROPERTIES = YAML.
+  load_file('spec/fixtures/valid-mandatory-broker-config.yml').
+  fetch('instance_groups').
+  first.
+  fetch('jobs').
+  first.
+  fetch('properties')
 
 class BoshEmulator
   extend ::Bosh::Template::PropertyHelper


### PR DESCRIPTION
This shows how the job template specs can be rewritten to use the `Bosh::Template::Test` module instead of the unofficial `BoshEmulator`.

There is also an opportunity to move away from using YAML fixtures, so that the properties values under test are more clear.

cc: @simonjjones 