### PR TITLE
Provide access to a specified org when service access is set to manual

### DIFF
--- a/jobs/register-broker/spec
+++ b/jobs/register-broker/spec
@@ -38,6 +38,10 @@ properties:
   cf.admin_password:
     description: Cloud Foundry admin password
 
+  default_access_org:
+    description: Enable service access to the specified org if enable_service_access is set to true and cf_service_access is set to "manual"
+    example: system
+
   enable_service_access:
     default: true
     description: Enable service access to the listed service plans

--- a/jobs/register-broker/templates/errand.sh.erb
+++ b/jobs/register-broker/templates/errand.sh.erb
@@ -67,7 +67,11 @@ cf $broker_cmd $broker_name <%= escape_shell(link('broker').p('username')) %> <%
         cf enable-service-access <%= link('broker').p('service_catalog.service_name') %> -p <%= plan.fetch('name') %>
       <% elsif plan.fetch('cf_service_access') == 'disable' %>
         cf disable-service-access <%= link('broker').p('service_catalog.service_name')%> -p <%= plan.fetch('name') %>
-      <% elsif plan.fetch('cf_service_access') != 'manual'
+      <% elsif plan.fetch('cf_service_access') == 'manual' %>
+        <% if_p('default_access_org') do |org| %>
+        cf enable-service-access <%= link('broker').p('service_catalog.service_name') %> -o <%= org %> -p <%= plan.fetch('name') %>
+        <% end %>
+      <% else
           raise "Unsupported value #{plan.fetch('cf_service_access')} for cf_service_access. Choose from \"enable\", \"disable\", \"manual\""
       %>
     <% end %>


### PR DESCRIPTION
Hello! [We're working on a story](https://www.pivotaltracker.com/story/show/160910536) on the dedicated-mysql team to allow platform operators to enable access to the system org by default when registering a broker.

Our proposed solution is as follows:
- add the default_access_org property to register-broker errand, if
  configured the enable service access will be run for this org
  every time the register-broker errand is run.

This PR is a WIP, as I wasn't sure of the best way to [fix the tests that get broken by this change.](https://github.com/pivotal-cf/on-demand-service-broker/blob/26c0ec142a8b48f2e3a54b960bf4fa75251a8284/system_tests/broker_registration_tests/broker_registration_test.go#L72-L75) Let us know if you have any comments or questions, thanks!