### PR TITLE
Add cf service access org-restricted

### DIFF
--- a/jobs/broker/templates/broker.yml.erb
+++ b/jobs/broker/templates/broker.yml.erb
@@ -11,7 +11,7 @@ required_instance_group_keys = ['name', "vm_type", "instances", "networks", "azs
 required_binding_with_dns_keys = ['name', 'link_provider', 'instance_group']
 valid_binding_with_dns_properties = ['azs', 'status']
 valid_dns_status = ['default', 'healthy', 'unhealthy', 'all']
-valid_cf_service_access_values = ['enable', 'disable', 'manual']
+valid_cf_service_access_values = ['enable', 'disable', 'manual', 'org-restricted']
 
 def validate_config(hash, keys, message)
   keys.each do |key|
@@ -159,7 +159,7 @@ plans.each do |plan|
   end
 
   if plan.has_key?('cf_service_access') && !valid_cf_service_access_values.include?(plan.fetch('cf_service_access'))
-    raise "Unsupported value '#{plan.fetch('cf_service_access')}' for cf_service_access. Choose from \"enable\", \"disable\", \"manual\""
+    raise "Unsupported value '#{plan.fetch('cf_service_access')}' for cf_service_access. Choose from \"enable\", \"disable\", \"manual\", \"org-restricted\""
   end
 
   if plan.has_key?('binding_with_dns')

--- a/jobs/register-broker/spec
+++ b/jobs/register-broker/spec
@@ -25,6 +25,10 @@ properties:
   broker_uri:
     description: URI of broker, if a route has been registered (optional)
 
+  default_access_org:
+    default: system
+    description: Enable service access to the specified org if enable_service_access is set to true and cf_service_access is set to "org-restricted"
+
   disable_ssl_cert_verification:
     default: false
     description: disable TLS certificate verification

--- a/jobs/register-broker/templates/errand.sh.erb
+++ b/jobs/register-broker/templates/errand.sh.erb
@@ -67,8 +67,10 @@ cf $broker_cmd $broker_name <%= escape_shell(link('broker').p('username')) %> <%
         cf enable-service-access <%= link('broker').p('service_catalog.service_name') %> -p <%= plan.fetch('name') %>
       <% elsif plan.fetch('cf_service_access') == 'disable' %>
         cf disable-service-access <%= link('broker').p('service_catalog.service_name')%> -p <%= plan.fetch('name') %>
+      <% elsif plan.fetch('cf_service_access') == 'org-restricted' %>
+        cf enable-service-access <%= link('broker').p('service_catalog.service_name')%> -o <%= escape_shell(p('default_access_org')) %> -p <%= plan.fetch('name') %>
       <% elsif plan.fetch('cf_service_access') != 'manual'
-          raise "Unsupported value #{plan.fetch('cf_service_access')} for cf_service_access. Choose from \"enable\", \"disable\", \"manual\""
+          raise "Unsupported value #{plan.fetch('cf_service_access')} for cf_service_access. Choose from \"enable\", \"disable\", \"manual\", \"org-restricted\""
       %>
     <% end %>
   <% end %>

--- a/spec/broker_config_template_spec.rb
+++ b/spec/broker_config_template_spec.rb
@@ -654,7 +654,7 @@ RSpec.describe 'broker config templating' do
       end
       it 'raises an error' do
         expect { rendered_template }.to(
-          raise_error(RuntimeError, "Unsupported value 'invalid' for cf_service_access. Choose from \"enable\", \"disable\", \"manual\"")
+          raise_error(RuntimeError, "Unsupported value 'invalid' for cf_service_access. Choose from \"enable\", \"disable\", \"manual\", \"org-restricted\"")
         )
       end
     end

--- a/spec/fixtures/register_broker_with_special_characters.yml
+++ b/spec/fixtures/register_broker_with_special_characters.yml
@@ -11,6 +11,7 @@ instance_groups:
       properties:
         broker_name: a-broker
         disable_ssl_cert_verification: true
+        default_access_org: "cf_org"
         cf:
           api_url: a-cf-url
           admin_username: "%cf_username'\"t:%!"

--- a/spec/register_broker_errand_spec.rb
+++ b/spec/register_broker_errand_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe 'register-broker errand' do
       end
     end
 
+    context 'and it has cf_service_access org-restricted' do
+      let(:access_value) { 'org-restricted' }
+
+      it "change the access for default access org" do
+        expect(rendered_template).to include 'cf enable-service-access myservicename -o \'cf_org\''
+        expect(rendered_template).to_not include 'cf disable-service-access'
+      end
+    end
+
+
     context 'and it does not specify cf_service_access' do
       let(:plans) do
         [
@@ -122,7 +132,7 @@ RSpec.describe 'register-broker errand' do
       it 'fails to template the errand' do
         expect do
           rendered_template
-        end.to raise_error(RuntimeError, 'Unsupported value foo-bar for cf_service_access. Choose from "enable", "disable", "manual"')
+        end.to raise_error(RuntimeError, 'Unsupported value foo-bar for cf_service_access. Choose from "enable", "disable", "manual", "org-restricted"')
       end
     end
   end


### PR DESCRIPTION
This is a follow up of the original PR here: https://github.com/pivotal-cf/on-demand-service-broker-release/pull/24

* Once cf_service_access is configured as 'org-restricted', ODB will
  automatically grant access of the services created to org 'default_access_org'.

[#160910536]

Signed-off-by: Andrew Garner <agarner@pivotal.io>
