### PR TITLE
create-and-upload-releases now works from any location

### DIFF
--- a/vbox/create-and-upload-releases.sh
+++ b/vbox/create-and-upload-releases.sh
@@ -2,9 +2,10 @@
 
 set -eu
 
-release_path=${1:-"."}
-
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+release_path=${1:-"$BASE_DIR/.."}
+
 source "$BASE_DIR/config.sh"
 
 echo ""


### PR DESCRIPTION
Running `vbox/create-and-upload-releases.sh` from vbox/ didn't work
unless you specify the ODB release path as an argument. This is a bit
counter intuitive given the `vbox/make-vbox-cf-env` does work from other
locations.

This change allows the `vbox/create-and-upload-releases.sh` to be
decoupled from a given location when an argument is not passed.