### PR TITLE
Update indicator protocol to v1

### DIFF
--- a/jobs/broker/templates/indicators.yml.erb
+++ b/jobs/broker/templates/indicators.yml.erb
@@ -124,4 +124,4 @@ def whole_doc
 end
 %>
 
-    <%= whole_doc %>
+<%= whole_doc %>

--- a/jobs/broker/templates/indicators.yml.erb
+++ b/jobs/broker/templates/indicators.yml.erb
@@ -4,14 +4,20 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
----
-
 <%
 require 'yaml'
 
 def global_thresholds
   if_p('service_catalog.global_quotas.service_instance_limit') do |limit|
-    return "[{level: critical, gte: #{limit}}, {level: warning, gte: #{(limit * 0.8).to_i}}]"
+    return [{
+      "level" => "critical",
+      "operator" => "gte",
+      "value" => limit
+    }, {
+      "level" => "warning",
+      "operator" => "gte",
+      "value" => (limit * 0.8).to_i
+    }]
   end
   return []
 end
@@ -20,16 +26,29 @@ def service_name
   return p('service_catalog.service_name').gsub("-", "_")
 end
 
-def render_plan_indicators
-  if all_plans_indicators.empty?
-    ""
-  else
-    "#{all_plans_indicators.to_yaml.gsub("---\n", "")}"
-  end
-end
+def all_indicators
 
-def all_plans_indicators
-  indicators = []
+  indicators = [{
+    "name" => "global_total_instances",
+    "promql" => "_on_demand_broker_#{service_name}_total_instances{deployment=\"$deployment\",source_id=\"$source_id\"}",
+    "thresholds" => global_thresholds,
+    "documentation" => {
+      "title" => "Global Service Instance Count",
+      "description" => "This metric indicates the total number of instances used across all plans.",
+      "thresholdNote" => "Threshold is set using the service instance limit in global quotas if configured.",
+      "recommendedResponse" =>
+        "When this metric gets to warning or critical level you should consider deleting any unused service instances,
+        or increase the global service instance limit."
+    },
+    "presentation" => {
+      "chartType" => "step",
+      "currentValue" => "false",
+      "frequency" => 0,
+      "labels" => ["source_id", "origin"],
+      "units" => "count",
+    }
+  }]
+
   if_p('service_catalog.plans') do |plans|
     plans.compact.each do |plan|
       indicators << plan_indicator(plan['name'], plan['quotas'])
@@ -44,7 +63,10 @@ def plan_indicator(plan_name, plan_quota)
    thresholds = []
    if !plan_quota.nil? && !plan_quota['service_instance_limit'].nil?
       limit = plan_quota['service_instance_limit']
-      thresholds = [{"level" => "critical", "gte" => limit}, {"level" => "warning" , "gte" => (limit * 0.8).to_i}]
+      thresholds = [
+          {"level" => "critical", "operator" => "gte", "value" => limit},
+          {"level" => "warning" , "operator" => "gte", "value" => (limit * 0.8).to_i}
+      ]
    end
    plan_name_with_underscore = plan_name.gsub("-", "_")
 
@@ -68,42 +90,38 @@ def plan_indicator(plan_name, plan_quota)
   },
 }
 end
+
+def whole_doc
+  return {
+  "apiVersion" => "indicatorprotocol.io/v1",
+  "kind" => "IndicatorDocument",
+  "metadata" => {
+    "labels" => {
+      "deployment" => "#{spec.deployment}",
+      "source_id" => "#{spec.deployment}"
+    },
+  },
+
+  "spec" => {
+    "product" => {
+      "name" => "#{spec.deployment}",
+      "version" => "1.0.0"
+    },
+    "indicators" => all_indicators,
+    "layout" => {
+      "owner" => "Services Enablement",
+      "title" => "On Demand Broker Monitoring",
+      "description" => "This topic explains how to monitor the On Demand Broker Indicators",
+      "sections" => [{
+        "title" => "Service Instance Quotas",
+        "description" => "Indicators monitoring service instance quota",
+        "indicators" => all_indicators.map { |indicator| indicator["name"] }
+      }]
+    }
+  }
+}.to_yaml
+
+end
 %>
 
-apiVersion: v0
-
-product:
-  name: <%= spec.deployment %>
-  version: 1.0.0
-
-metadata:
-  deployment: <%= spec.deployment %>
-  source_id: <%= spec.deployment %>
-
-indicators:
-- name: global_total_instances
-  promql: _on_demand_broker_<%= service_name %>_total_instances{deployment="$deployment",source_id="$source_id"}
-  thresholds: <%= global_thresholds %>
-  documentation:
-    title: Global Service Instance Count
-    description: This metric indicates the total number of instances used across all plans.
-    thresholdNote: Threshold is set using the service instance limit in global quotas if configured.
-    recommendedResponse: |
-      When this metric gets to warning or critical level you should consider deleting any unused service instances,
-      or increase the global service instance limit.
-  presentation:
-    chartType: step
-    currentValue: false
-    frequency: 0
-    labels: [source_id, origin]
-    units: "count"
-<%= render_plan_indicators %>
-
-layout:
-  owner: Services Enablement
-  title: On Demand Broker Monitoring
-  description: This topic explains how to monitor the On Demand Broker Indicators
-  sections:
-  - title: Service Instance Quotas
-    description: Indicators monitoring service instance quota
-    indicators: <%= ["global_total_instances"] | all_plans_indicators.map { |indicator| indicator['name']} %>
+    <%= whole_doc %>

--- a/spec/indicators_spec.rb
+++ b/spec/indicators_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'indicator config templating' do
   }
 
   let(:indicator) {
-    rendered_template['indicators'].filter {|i| i['name'] == indicator_name}[0]
+    rendered_template['spec']['indicators'].filter {|i| i['name'] == indicator_name}[0]
   }
 
   before(:all) do
@@ -48,7 +48,7 @@ RSpec.describe 'indicator config templating' do
         "name" => "my-deployment",
         "version" => "1.0.0"
     }
-    expect(rendered_template['product']).to eq(expected_product)
+    expect(rendered_template['spec']['product']).to eq(expected_product)
   end
 
   it 'sets `metadata` correctly' do
@@ -56,17 +56,17 @@ RSpec.describe 'indicator config templating' do
         "deployment" => "my-deployment",
         "source_id" => "my-deployment",
     }
-    expect(rendered_template['metadata']).to eq(expected_metadata)
+    expect(rendered_template['metadata']['labels']).to eq(expected_metadata)
   end
 
   describe 'layout' do
     it 'should be not empty' do
-      expect(rendered_template['layout']).not_to be_nil
-      expect(rendered_template['layout']['title']).not_to be_nil
-      expect(rendered_template['layout']['owner']).not_to be_nil
-      expect(rendered_template['layout']['description']).not_to be_nil
+      expect(rendered_template['spec']['layout']).not_to be_nil
+      expect(rendered_template['spec']['layout']['title']).not_to be_nil
+      expect(rendered_template['spec']['layout']['owner']).not_to be_nil
+      expect(rendered_template['spec']['layout']['description']).not_to be_nil
 
-      sections = rendered_template['layout']['sections']
+      sections = rendered_template['spec']['layout']['sections']
       expect(sections).to include a_hash_including('indicators' => include('global_total_instances', 'dedicated_vm_total_instances', 'dedicated_high_mem_vm_total_instances',))
       expect(sections).to include a_hash_including('indicators' => start_with('global_total_instances'))
     end
@@ -95,8 +95,8 @@ RSpec.describe 'indicator config templating' do
 
         it 'is configured correctly' do
           expected_thresholds = [
-              {"level" => "critical", "gte" => 200},
-              {"level" => "warning", "gte" => (200 * 0.8).to_i}
+              {"level" => "critical", "operator" => "gte", "value" => 200},
+              {"level" => "warning", "operator" => "gte", "value" => (200 * 0.8).to_i}
           ]
           expect(indicator['thresholds']).to eq expected_thresholds
         end
@@ -129,10 +129,10 @@ RSpec.describe 'indicator config templating' do
       end
 
       it "has only the global total instances" do
-        total_instances_indicator = rendered_template["indicators"].filter {|indicator| indicator["name"].end_with? "total_instances"}
+        total_instances_indicator = rendered_template['spec']["indicators"].filter {|indicator| indicator["name"].end_with? "total_instances"}
         expect(total_instances_indicator.size).to eq 1
 
-        sections = rendered_template['layout']['sections'][0]["indicators"]
+        sections = rendered_template['spec']['layout']['sections'][0]["indicators"]
         sections_for_total_instances = sections.filter {|s| s.end_with? "total_instances"}
         expect(sections_for_total_instances).to contain_exactly 'global_total_instances'
       end
@@ -154,7 +154,7 @@ RSpec.describe 'indicator config templating' do
         end
 
         it 'ignores the plan' do
-          expect(rendered_template['indicators'].size).to eq 2
+          expect(rendered_template['spec']['indicators'].size).to eq 2
         end
       end
 
@@ -168,8 +168,8 @@ RSpec.describe 'indicator config templating' do
 
           it 'is configured correctly' do
             expected_thresholds = [
-                {"level" => "critical", "gte" => 150},
-                {"level" => "warning", "gte" => 120}
+                {"level" => "critical", "operator" => "gte", "value" => 150},
+                {"level" => "warning", "operator" => "gte", "value" => 120}
             ]
             expect(indicator['thresholds']).to eq expected_thresholds
           end


### PR DESCRIPTION
With this PR, updates the indicator protocol to v1 as v0 has been deprecated as of https://github.com/pivotal/monitoring-indicator-protocol/commit/1e1464e8a318a133e769264abdef69c144c5a482

Let me know if you have questions!