### PR TITLE
add allowpublic as a valid uaa.client_definition property

### DIFF
--- a/jobs/broker/templates/broker.yml.erb
+++ b/jobs/broker/templates/broker.yml.erb
@@ -393,7 +393,7 @@ def normalise_cf_authentication(cf)
   if cf['uaa']['client_definition'].nil?
     cf['uaa'].delete('client_definition')
   else
-    valid_props = %w{scopes authorities authorized_grant_types resource_ids name}
+    valid_props = %w{scopes authorities authorized_grant_types resource_ids allowpublic name}
     cf['uaa']['client_definition'].keys.each do |k|
       raise "Invalid client_definition config - valid properties are: #{valid_props.join(", ")}" unless valid_props.include? k
     end

--- a/spec/broker_config_template_spec.rb
+++ b/spec/broker_config_template_spec.rb
@@ -799,7 +799,8 @@ RSpec.describe 'broker config templating' do
           'resource_ids' => 'some-resource-id',
           'authorized_grant_types' => 'some-authorization',
           'authorities' => 'some-authority,another-authority',
-          'name' => 'some-name'
+          'name' => 'some-name',
+          'allowpublic' => true,
         }
       }
 
@@ -826,7 +827,7 @@ RSpec.describe 'broker config templating' do
         it 'raises an error' do
           expect do
             rendered_template
-          end.to raise_error(RuntimeError, 'Invalid client_definition config - valid properties are: scopes, authorities, authorized_grant_types, resource_ids, name')
+          end.to raise_error(RuntimeError, 'Invalid client_definition config - valid properties are: scopes, authorities, authorized_grant_types, resource_ids, allowpublic, name')
         end
       end
 


### PR DESCRIPTION
This property was added to the broker in
pivotal-cf/on-demand-service-broker#189 and this change allows the property to actually be configured in a bosh deployment.

A related system test was added in pivotal-cf/on-demand-service-broker#195.

[#184630501](https://www.pivotaltracker.com/story/show/184630501)

Authored-by: Andrew Garner <garnera@vmware.com>