### PR TITLE
Support stemcell name property

### DIFF
--- a/jobs/broker/spec
+++ b/jobs/broker/spec
@@ -217,6 +217,9 @@ properties:
       - os: ubuntu
         version: 1234
 
+  service_deployment.stemcell.name:
+    description: stemcell name to use for every job in the service deployment
+
   service_deployment.stemcell.os:
     description: stemcell OS to use for every job in the service deployment
 

--- a/jobs/broker/templates/broker.yml.erb
+++ b/jobs/broker/templates/broker.yml.erb
@@ -95,6 +95,7 @@ def prepare_stemcells(service_deployment)
     raise 'Invalid service_deployment config - at least one stemcell must be specified'
   end
 
+  service_deployment['stemcells'].map! { |stemcell| stemcell.compact }
   service_deployment['stemcells'].each do |stemcell|
     validate_stemcell stemcell
   end

--- a/spec/broker_config_template_spec.rb
+++ b/spec/broker_config_template_spec.rb
@@ -1143,7 +1143,7 @@ RSpec.describe 'broker config templating' do
         generate_test_manifest do |yaml|
           yaml['instance_groups'][0]['jobs'][0]['properties']['service_deployment']['stemcells'] = []
           yaml['instance_groups'][0]['jobs'][0]['properties']['service_deployment']['stemcell'] = {
-            'os' => 'ubuntu-trusty', 'version' => 2311
+            'os' => 'ubuntu-trusty', 'version' => "2311", 'name' => 'bosh-warden-boshlite-ubuntu-trusty-go_agent',
           }
           yaml
         end
@@ -1152,7 +1152,7 @@ RSpec.describe 'broker config templating' do
 
       it 'generates the config with "stemcells"' do
         obj = YAML.load(rendered_template)
-        expect(obj['service_deployment']['stemcells']).to eq([{"os"=>"ubuntu-trusty", "version"=>2311}])
+        expect(obj['service_deployment']['stemcells']).to eq([{"os"=>"ubuntu-trusty", "version"=>"2311", "name" => "bosh-warden-boshlite-ubuntu-trusty-go_agent"}])
         expect(obj['service_deployment']['stemcell']).to be_nil
       end
 


### PR DESCRIPTION
Broadcom has started supporting FIPS enabled stemcells whose version matches the non-FIPS stemcells and without a name specified the FIPS may unintentionally be used when a deployment might not support FIPS.

To avoid this allow consumers to set a stemcell name property to point to the expected stemcell name. This allows BOSH to ensure the desired stemcell is always used and not unintentionally deploying with the wrong variant.

This commit updates the spec property of the broker job to allow defining the stemcell.name or stemcells[].name property for a data service product.

To fully support the name property this depends on changes in the ODB SDK in https://github.com/pivotal-cf/on-demand-services-sdk/pull/200