### PR TITLE
Add skip_check_for_pending_changes option to broker

### DIFF
--- a/jobs/broker/spec
+++ b/jobs/broker/spec
@@ -327,5 +327,15 @@ properties:
     description: If the service adapter supports backup agent URL bindings, set this flag to true
     default: false
 
+  skip_check_for_pending_changes:
+    description: >
+      If true, the broker will allow updates to a service instance with pending changes that would otherwise require an
+      upgrade.
+      This enables `cf update-service -c '{}'` to effectively update an instance even if the current manifest does not
+      match the view of the service adapter.
+      When false (the default), attempts to update a service instance whose manifest would change results in an error:
+      "The service broker has been updated, and this service instance is out of date. Please contact your operator"
+    default: false
+
   cf.authentication:
     description: (Deprecated) UAA authentication object. See cf.uaa.

--- a/jobs/broker/templates/broker.yml.erb
+++ b/jobs/broker/templates/broker.yml.erb
@@ -475,6 +475,7 @@ config = {
     "enable_secure_manifests" => p('enable_secure_manifests'),
     "enable_telemetry" => p('enable_telemetry'),
     "support_backup_agent_binding" => p('support_backup_agent_binding'),
+    "skip_check_for_pending_changes" => p('skip_check_for_pending_changes'),
   }.merge(tls_config),
   "bosh" => bosh_config,
   "cf" => cf_config,


### PR DESCRIPTION
This flag controls whether "update-service" fails with a broker.PendingChangesNotAppliedError or succeeds in the event that the previous manifest does not match the new manifest.

This check disallows a developer from updating their service instance when an upgrade is pending - putting the control for rolling out a new version of software in the handles of the platform engineer.

In many cases, a platform engineer may want to delegate the update to the developer anyway.  This is a feature flag to allow the platform engineer to permit updates even if the manifest is changing and effectively an upgrade is applied.