### PR TITLE
Removes references to manifest persist feature

### DIFF
--- a/jobs/broker/spec
+++ b/jobs/broker/spec
@@ -327,9 +327,5 @@ properties:
     description: If the service adapter supports backup agent URL bindings, set this flag to true
     default: false
 
-  enable_persist_manifest:
-    description: If true, the broker will record manifests in /var/vcap/data/manifests/
-    default: false
-
   cf.authentication:
     description: (Deprecated) UAA authentication object. See cf.uaa.

--- a/jobs/broker/templates/bpm.yml.erb
+++ b/jobs/broker/templates/bpm.yml.erb
@@ -25,14 +25,10 @@ bpm_config = {
       '-configFilePath',
       '/var/vcap/jobs/broker/config/broker.yml'
       ],
-    'additional_volumes' => [],
     'unsafe' => {
       'unrestricted_volumes' => unrestricted_volumes
     }
   }]
 }
-
-bpm_config['processes'][0]['additional_volumes'] << {'path' => '/var/vcap/data/broker/manifest', 'writable' => true}
-
 bpm_config.to_yaml
 %>

--- a/jobs/broker/templates/broker.yml.erb
+++ b/jobs/broker/templates/broker.yml.erb
@@ -475,7 +475,6 @@ config = {
     "enable_secure_manifests" => p('enable_secure_manifests'),
     "enable_telemetry" => p('enable_telemetry'),
     "support_backup_agent_binding" => p('support_backup_agent_binding'),
-    "enable_persist_manifest" => p('enable_persist_manifest')
   }.merge(tls_config),
   "bosh" => bosh_config,
   "cf" => cf_config,

--- a/spec/broker_bpm_spec.rb
+++ b/spec/broker_bpm_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe 'broker bpm templating' do
       config = YAML.safe_load(rendered_template)
       expected = {
         'processes' => [{
-          'additional_volumes'=>[{'path'=>'/var/vcap/data/broker/manifest', 'writable'=>true}],
           'name' => 'broker',
           'env' => {'GODEBUG' => 'tls13=0'},
           'executable' => '/var/vcap/packages/broker/bin/on-demand-service-broker',

--- a/spec/broker_config_template_spec.rb
+++ b/spec/broker_config_template_spec.rb
@@ -1726,46 +1726,6 @@ RSpec.describe 'broker config templating' do
       end
     end
   end
-
-  describe 'manifest persisting support' do
-      context 'when not set' do
-        let(:manifest_file) do
-          generate_test_manifest do |yaml|
-            yaml['instance_groups'][0]['jobs'][0]['properties'].delete('enable_persist_manifest')
-          end
-        end
-
-        it 'defaults to false' do
-          expect(rendered_template).to include 'enable_persist_manifest: false'
-        end
-      end
-
-      context 'when disabled' do
-        let(:manifest_file) do
-          generate_test_manifest do |yaml|
-            yaml['instance_groups'][0]['jobs'][0]['properties']['enable_persist_manifest'] = false
-          end
-        end
-
-        it 'is set to false' do
-          config = YAML.safe_load(rendered_template)
-          expect(config.dig('broker', 'enable_persist_manifest')).to eq(false)
-        end
-      end
-
-      context 'when enabled' do
-        let(:manifest_file) do
-          generate_test_manifest do |yaml|
-            yaml['instance_groups'][0]['jobs'][0]['properties']['enable_persist_manifest'] = true
-          end
-        end
-
-        it 'is set to true' do
-          config = YAML.safe_load(rendered_template)
-          expect(config.dig('broker', 'enable_persist_manifest')).to eq(true)
-        end
-      end
-    end
 end
 
 def generate_test_manifest


### PR DESCRIPTION
Reverts 4e59b3ff7f0d7910c4a8fa764749514a4c4880cb

Based on decision to better address customer needs by allowing the broker to continue even when manifests do not match

[TNZ-22489](https://vmw-jira.broadcom.net/browse/TNZ-22489)

Authored-by: Ryan Wittrup <ryan.wittrup@broadcom.com>